### PR TITLE
Add -e to the install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ CMD ["django-entrypoint.sh"]
 
 ONBUILD COPY . /app
 ONBUILD WORKDIR /app
-ONBUILD RUN pip install .
+ONBUILD RUN pip install -e .


### PR DESCRIPTION
Makes things behave more like the source is actually there (which it is)
