### PR TITLE
SEED-793: Use Nginx to serve everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - docker build --tag mysite --file "example/$DOCKERFILE" example
   - docker run --detach --name mysite -p 8000:8000 mysite && sleep 5
   # Simple check to see if the site is up
-  - curl -fs http://localhost:8000 | fgrep '<h1>It worked!</h1>'
+  - curl -fsL http://localhost:8000/admin | fgrep '<title>Log in | Django site admin</title>'
   - docker stop mysite
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ It's a good idea to have Docker ignore the `.git` directory because every git op
 Gunicorn is run with some basic configuration:
 * Runs WSGI app defined in `APP_MODULE` environment variable
 * Listens on a Unix socket at `/var/run/gunicorn.sock`
-* Logs access logs to stderr
+* Access logs can be logged to stderr by setting the `GUNICORN_ACCESS_LOGS` environment variable to a non-empty value.
 
 Extra settings can be provided by overriding the `CMD` instruction to pass extra parameters to the entrypoint script. For example:
 ```dockerfile

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ If your project makes use of user-uploaded media files, it must be set up as fol
 * `MEDIA_URL = '/media/'`
 * `MEDIA_ROOT` = `BASE_DIR/media` or `BASE_DIR/mediafiles`
 
+***Note:*** Any files stored in directories called `static`, `staticfiles`, `media`, or `mediafiles` in the project root directory will be served by Nginx. Do not store anything here that you do not want the world to see.
+
 #### Step 1: Write a Dockerfile
 In the root of the repo for your Django project, add a Dockerfile for the project. For example, this file could contain:
 ```dockerfile

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Dockerfile for quickly running Django projects in a Docker container.
 Run [Django](https://www.djangoproject.com) projects from source using [gunicorn](http://gunicorn.org).
 
 ## Usage
+#### Step 0: Get your Django project in shape
+There are a few ways that your Django project needs to be set up in order to be compatible with this Docker image.
+* Your project must have a `setup.py`. All dependencies (including Django itself) need to be listed as `install_requires`.
+* Your project's [static files](https://docs.djangoproject.com/en/1.9/howto/static-files/) must be served from the `/static/` path (i.e. `STATIC_PATH` must be set to that) and must be stored at `BASE_DIR/static` (i.e. `STATIC_ROOT` must be set to that).
+* Your project's media files must be served from `/media/` (`MEDIA_URL`) and must be stored at `BASE_DIR/media` (`MEDIA_ROOT`).
+
 #### Step 1: Write a Dockerfile
 In the root of the repo for your Django project, add a Dockerfile for the project. For example, this file could contain:
 ```dockerfile
@@ -48,13 +54,6 @@ Add a file called `.dockerignore` to the root of your project. At a minimum, it 
 Docker uses various caching mechanisms to speed up image build times. One of those mechanisms is to detect if any of the files being `ADD`/`COPY`-ed to the image have changed. You can add a `.dockerignore` file to have Docker ignore changes to certain files. This is conceptually similar to a `.gitignore` file but has different syntax. For more information, see the [Docker documentation](https://docs.docker.com/engine/reference/builder/#dockerignore-file).
 
 It's a good idea to have Docker ignore the `.git` directory because every git operation you perform will result in files changing in that directory (whether you end up in the same state in git as you previously were or not). Also, you probably shouldn't be working with your git repo inside the container.
-
-#### Step 3: Use a static file serving middleware *(optional but recommended)*
-Choose one of the following projects to use to serve static files:
-* [DJ-Static](https://github.com/kennethreitz/dj-static)
-* [WhiteNoise](http://whitenoise.evans.io)
-
-Serving static files using Django is generally not advised due to performance issues. In pre-Docker land, we would normally use something like Nginx to serve all the static files at the `/static/` path. But with Docker (and Seed Stack), we're not necessarily sure where our containers are running and their filesystems are fairly isolated from the outside world. We'd also like to keep to running a single process in each Docker container and running Nginx inside a container gets a bit complicated.
 
 ## Configuration
 Gunicorn is run with some basic configuration:

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Run [Django](https://www.djangoproject.com) projects from source using [Gunicorn
 #### Step 0: Get your Django project in shape
 There are a few ways that your Django project needs to be set up in order to be compatible with this Docker image.
 * Your project must have a `setup.py`. All dependencies (including Django itself) need to be listed as `install_requires`.
-* Your project's [static files](https://docs.djangoproject.com/en/1.9/howto/static-files/) must be served from the `/static/` path (i.e. `STATIC_PATH` must be set to that) and must be stored at `BASE_DIR/static` (i.e. `STATIC_ROOT` must be set to that).
-* Your project's media files must be served from `/media/` (`MEDIA_URL`) and must be stored at `BASE_DIR/media` (`MEDIA_ROOT`).
+* Your project's [static files](https://docs.djangoproject.com/en/1.9/howto/static-files/) must be served from the `/static/` path (i.e. `STATIC_PATH` must be set to that) and must be stored in either `BASE_DIR/static` or `BASE_DIR/staticfiles` (i.e. `STATIC_ROOT` must be set to one of those).
+* Your project's media files must be served from `/media/` (`MEDIA_URL`) and must be stored in either `BASE_DIR/media` or `BASE_DIR/mediafiles` (`MEDIA_ROOT`).
 
 #### Step 1: Write a Dockerfile
 In the root of the repo for your Django project, add a Dockerfile for the project. For example, this file could contain:

--- a/README.md
+++ b/README.md
@@ -6,9 +6,19 @@ Run [Django](https://www.djangoproject.com) projects from source using [Gunicorn
 ## Usage
 #### Step 0: Get your Django project in shape
 There are a few ways that your Django project needs to be set up in order to be compatible with this Docker image.
-* Your project must have a `setup.py`. All dependencies (including Django itself) need to be listed as `install_requires`.
-* Your project's [static files](https://docs.djangoproject.com/en/1.9/howto/static-files/) must be served from the `/static/` path (i.e. `STATIC_PATH` must be set to that) and must be stored in either `BASE_DIR/static` or `BASE_DIR/staticfiles` (i.e. `STATIC_ROOT` must be set to one of those).
-* Your project's media files must be served from `/media/` (`MEDIA_URL`) and must be stored in either `BASE_DIR/media` or `BASE_DIR/mediafiles` (`MEDIA_ROOT`).
+
+**setup.py**  
+Your project must have a `setup.py`. All dependencies (including Django itself) need to be listed as `install_requires`.
+
+**Static files**  
+Your project's [static files](https://docs.djangoproject.com/en/1.9/howto/static-files/) must be set up as follows:
+* `STATIC_URL = '/static/'`
+* `STATIC_ROOT` = `BASE_DIR/static` or `BASE_DIR/staticfiles`
+
+**Media files**  
+If your project makes use of user-uploaded media files, it must be set up as follows:
+* `MEDIA_URL = '/media/'`
+* `MEDIA_ROOT` = `BASE_DIR/media` or `BASE_DIR/mediafiles`
 
 #### Step 1: Write a Dockerfile
 In the root of the repo for your Django project, add a Dockerfile for the project. For example, this file could contain:

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,12 +1,16 @@
 FROM praekeltfoundation/python-base:alpine
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
-# Dependencies for psycopg2
-RUN apk --no-cache add libpq
+# Install libpq for PostgreSQL support and Nginx to serve everything
+RUN apk --no-cache add libpq nginx
 
-# Install gunicorn and the entrypoint script
+# Install gunicorn
 RUN pip install gunicorn
+
+# Copy in the config files
+COPY ./nginx/ /etc/nginx/
 COPY ./django-entrypoint.sh /scripts/
+
 EXPOSE 8000
 
 CMD ["django-entrypoint.sh"]

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -7,12 +7,12 @@ RUN apk --no-cache add libpq nginx
 # Install gunicorn
 RUN pip install gunicorn
 
-# Copy in the config files
+# Copy in the Nginx config
 COPY ./nginx/ /etc/nginx/
-COPY ./django-entrypoint.sh /scripts/
 
 EXPOSE 8000
 
+COPY ./django-entrypoint.sh /scripts/
 CMD ["django-entrypoint.sh"]
 
 ONBUILD COPY . /app

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -1,12 +1,16 @@
 FROM praekeltfoundation/python-base:debian
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
-# Dependencies for psycopg2
-RUN apt-get-install.sh libpq5
+# Install libpq for PostgreSQL support and Nginx to serve everything
+RUN apt-get-install.sh libpq5 nginx-light
 
-# Install gunicorn and the entrypoint script
+# Install gunicorn
 RUN pip install gunicorn
+
+# Copy in the config files
+COPY ./nginx/ /etc/nginx/
 COPY ./django-entrypoint.sh /scripts/
+
 EXPOSE 8000
 
 CMD ["django-entrypoint.sh"]

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -2,7 +2,14 @@ FROM praekeltfoundation/python-base:debian
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
 # Install libpq for PostgreSQL support and Nginx to serve everything
-RUN apt-get-install.sh libpq5 nginx-light
+# Get Nginx from the upstream repo so that we're up-to-date with Alpine and have
+# a compatible config file.
+ENV NGINX_VERSION 1.10.1-1~jessie
+RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62 \
+    && echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list \
+    && apt-get-install.sh \
+        libpq5 \
+        nginx=${NGINX_VERSION}
 
 # Install gunicorn
 RUN pip install gunicorn

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -14,12 +14,12 @@ RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC64107
 # Install gunicorn
 RUN pip install gunicorn
 
-# Copy in the config files
+# Copy in the Nginx config
 COPY ./nginx/ /etc/nginx/
-COPY ./django-entrypoint.sh /scripts/
 
 EXPOSE 8000
 
+COPY ./django-entrypoint.sh /scripts/
 CMD ["django-entrypoint.sh"]
 
 ONBUILD COPY . /app

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -16,6 +16,7 @@ RUN pip install gunicorn
 
 # Copy in the Nginx config
 COPY ./nginx/ /etc/nginx/
+RUN rm /etc/nginx/conf.d/default.conf
 
 EXPOSE 8000
 

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -12,5 +12,5 @@ nginx
 
 exec gunicorn "$APP_MODULE" \
     --bind unix:/var/run/gunicorn.sock \
-    --access-logfile - \
+    "${GUNICORN_ACCESS_LOGS:+--access-logfile -}" \
     "$@"

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -12,5 +12,5 @@ nginx
 
 exec gunicorn "$APP_MODULE" \
     --bind unix:/var/run/gunicorn.sock \
-    "${GUNICORN_ACCESS_LOGS:+--access-logfile -}" \
+    ${GUNICORN_ACCESS_LOGS:+--access-logfile -} \
     "$@"

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -8,7 +8,9 @@ if [ -z "$APP_MODULE" ]; then
   exit 1
 fi
 
+nginx
+
 exec gunicorn "$APP_MODULE" \
-    --bind :8000 \
+    --bind unix:/var/run/gunicorn.sock \
     --access-logfile - \
     "$@"

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env sh
 set -e
 
-django-admin migrate --noinput
-
 if [ -z "$APP_MODULE" ]; then
   echo "The \$APP_MODULE environment variable must be set to the WSGI application module name"
   exit 1
 fi
+
+django-admin migrate --noinput
 
 nginx
 

--- a/example/alpine.dockerfile
+++ b/example/alpine.dockerfile
@@ -1,3 +1,4 @@
 FROM praekeltfoundation/django-bootstrap:alpine
 ENV DJANGO_SETTINGS_MODULE "mysite.settings"
+RUN django-admin collectstatic --noinput
 ENV APP_MODULE "mysite.wsgi:application"

--- a/example/debian.dockerfile
+++ b/example/debian.dockerfile
@@ -1,3 +1,4 @@
 FROM praekeltfoundation/django-bootstrap:debian
 ENV DJANGO_SETTINGS_MODULE "mysite.settings"
+RUN django-admin collectstatic --noinput
 ENV APP_MODULE "mysite.wsgi:application"

--- a/example/mysite/settings.py
+++ b/example/mysite/settings.py
@@ -119,3 +119,4 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, "static")

--- a/example/mysite/settings.py
+++ b/example/mysite/settings.py
@@ -23,9 +23,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = '2^!@63mf-#%l8m_v*o3hz(&2iw35o_6h^3^&x$+1rm558^)_i9'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
 
 
 # Application definition

--- a/nginx/conf.d/django.conf
+++ b/nginx/conf.d/django.conf
@@ -1,0 +1,20 @@
+server {
+    listen 8000;
+
+    location /static/ {
+        alias /app/static/;
+    }
+
+    location /media/ {
+        alias /app/media/;
+    }
+
+    location / {
+        proxy_pass http://unix:/var/run/gunicorn.sock;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/conf.d/django.conf
+++ b/nginx/conf.d/django.conf
@@ -1,3 +1,9 @@
+upstream gunicorn {
+    # Proxy to Gunicorn socket and always retry, as recommended by deployment
+    # guide: http://docs.gunicorn.org/en/stable/deploy.html
+    server unix:/var/run/gunicorn.sock max_fails=0;
+}
+
 server {
     listen 8000;
 
@@ -15,9 +21,7 @@ server {
     }
 
     location / {
-        # Proxy to Gunicorn socket and always retry, as recommended by
-        # deployment guide: http://docs.gunicorn.org/en/stable/deploy.html
-        proxy_pass http://unix:/var/run/gunicorn.sock max_fails=0;
+        proxy_pass http://gunicorn;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/conf.d/django.conf
+++ b/nginx/conf.d/django.conf
@@ -1,15 +1,17 @@
 server {
     listen 8000;
 
+    root /app;
+
     location ~ ^/static/?(.*)$ {
-        root /app;
         # Fallback for projects still using STATIC_ROOT = BASE_DIR/staticfiles
         # as recommended by WhiteNoise
         try_files /static/$1 /staticfiles/$1 =404;
     }
 
-    location /media/ {
-        alias /app/media/;
+    location ~ ^/media/?(.*)$ {
+        # Fallback for projects still using MEDIA_ROOT = BASE_DIR/mediafiles
+        try_files /media/$1 /mediafiles/$1 =404;
     }
 
     location / {

--- a/nginx/conf.d/django.conf
+++ b/nginx/conf.d/django.conf
@@ -1,8 +1,11 @@
 server {
     listen 8000;
 
-    location /static/ {
-        alias /app/static/;
+    location ~ ^/static/?(.*)$ {
+        root /app;
+        # Fallback for projects still using STATIC_ROOT = BASE_DIR/staticfiles
+        # as recommended by WhiteNoise
+        try_files /static/$1 /staticfiles/$1 =404;
     }
 
     location /media/ {

--- a/nginx/conf.d/django.conf
+++ b/nginx/conf.d/django.conf
@@ -15,7 +15,9 @@ server {
     }
 
     location / {
-        proxy_pass http://unix:/var/run/gunicorn.sock;
+        # Proxy to Gunicorn socket and always retry, as recommended by
+        # deployment guide: http://docs.gunicorn.org/en/stable/deploy.html
+        proxy_pass http://unix:/var/run/gunicorn.sock max_fails=0;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/conf.d/django.conf
+++ b/nginx/conf.d/django.conf
@@ -13,8 +13,6 @@ server {
         proxy_pass http://unix:/var/run/gunicorn.sock;
 
         proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,6 @@
+# Config is the default provided in the Debian Nginx 1.10.1 package--as used by
+# the official Nginx Docker images. Adjustments made to log to stdout/stderr.
+# https://github.com/nginxinc/docker-nginx/blob/1.10.1/stable/alpine/nginx.conf
 
 user  nginx;
 worker_processes  1;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,32 @@
+
+user  nginx;
+worker_processes  1;
+
+error_log  /dev/stderr warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /dev/stdout  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
I was hesitant to do this but it's starting to look like the best option.

WhiteNoise/DJ-Static don't handle user-uploaded media files. Nginx is looking like the best way to run this stuff, which I don't like, but at least we've found a way to run multiple things without Supervisor.

```
dinit(1)-+-gunicorn(9)---gunicorn(25)
         `-nginx(18)---nginx(19)
```
