### PR TITLE
Rework entrypoint script (now script*s*)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,18 @@ If your project makes use of user-uploaded media files, it must be set up as fol
 In the root of the repo for your Django project, add a Dockerfile for the project. For example, this file could contain:
 ```dockerfile
 FROM praekeltfoundation/django-bootstrap:onbuild
-ENV DJANGO_SETTINGS_MODULE "my_django_project.settings"
+ENV DJANGO_SETTINGS_MODULE my_django_project.settings
 RUN django-admin collectstatic --noinput
-ENV APP_MODULE "my_django_project.wsgi:application"
+CMD ["my_django_project.wsgi:application"]
 ```
 
 Let's go through these lines one-by-one:
  1. The `FROM` instruction here tells us which image to base this image on. We use the `django-bootstrap:onbuild` base image.
  2. We set the `DJANGO_SETTINGS_MODULE` environment variable so that Django knows where to find its settings. This is necessary for any `django-admin` commands to work.
  3. *Optional:* If you need to run any build-time tasks, such as collecting static assets, now's the time to do that.
- 4. We set the `APP_MODULE` environment variable that will be passed to `gunicorn`, which is installed and run in the `django-bootstrap` base image. `gunicorn` needs to know which WSGI application to run.
+ 4. We set the container command (`CMD`) to a list of arguments that will be passed to `gunicorn`. We need to provide Gunicorn with the [`APP_MODULE`](http://docs.gunicorn.org/en/stable/run.html?highlight=app_module#gunicorn), so that it knows which WSGI app to run.*
+
+\*Note that previously the way to do this was to set the `APP_MODULE` environment variable. That still works, but is no longer the recommended way.
 
 The `django-bootstrap:onbuild` base image does a few steps automatically using Docker's `ONBUILD` instruction. It will:
  1. `COPY . /app` - copies the source of your project into the image

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Note that by default Celery runs as many worker processes as there are processor
 * Celery option: `-c`/`--concurrency`
 
 #### `CELERY_BEAT`:
-Set this option to any non-empty value (e.g. "`1`") to have a [Celery beat](http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html) scheduler process run as well.
+Set this option to any non-empty value (e.g. `1`) to have a [Celery beat](http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html) scheduler process run as well.
 * Required: no
 * Default: none
 * Celery option: n/a

--- a/README.md
+++ b/README.md
@@ -47,19 +47,7 @@ All these instructions occur directly after the `FROM` instruction in your Docke
 
 By default, the [`django-entrypoint.sh`](django-entrypoint.sh) script is run when the container is started. This script runs a once-off `django-admin migrate` to update the database schemas and then launches `nginx` and `gunicorn` to run the application.
 
-This [`django-entrypoint.sh`](django-entry-point.sh) script also allows you to create a Django super user account if needed. Setting the `SUPERUSER_PASSWORD` environment variable will result in a Django superuser account being made with the `admin` username. This will only happen if no `admin` user exists.
-
-You can skip the execution of this script and run other commands by overriding the `CMD` instruction. For example, to run a Celery worker, add the following to your Dockerfile:
-```dockerfile
-CMD ["celery", "worker", \
-     "--app", "my_django_project", \
-     "--loglevel", "info"]
-```
-
-Alternatively, you can override the command at runtime:
-```shell
-docker run my_django_project_image celery worker --app my_django_project --loglevel info
-```
+The script also allows you to create a Django super user account if needed. Setting the `SUPERUSER_PASSWORD` environment variable will result in a Django superuser account being made with the `admin` username. This will only happen if no `admin` user exists.
 
 #### Step 2: Add a `.dockerignore` file (if using the `:onbuild` image)
 Add a file called `.dockerignore` to the root of your project. A good start is just to copy in the [`.dockerignore` file](example/.dockerignore) from the example Django project in this repo.
@@ -72,14 +60,56 @@ Additionally, you shouldn't need any *Git* stuff inside your Docker image. It's 
 
 **NOTE:** Unlike `.gitignore` files, `.dockerignore` files do *not* apply recursively to subdirectories. So, for example, while the entry `*.pyc` in a `.gitignore` file will cause Git to ignore `./abc.pyc` and `./def/ghi.pyc`, in a `.dockerignore` file, that entry will cause Docker to ignore only `./abc.pyc`. This is very unfortunate. In order to get the same behaviour from a `.dockerignore` file, you need to add an extra leading `**/` glob pattern — i.e. `**/*.pyc`. For more information on the `.dockerignore` file syntax, see the [Docker documentation](https://docs.docker.com/engine/reference/builder/#dockerignore-file).
 
-## Celery
-It's common for Django applications to have [Celery](http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html) workers performing tasks alongside the actual website. In most cases it makes sense to run each Celery process in a container separate from the Django/Gunicorn one, so as to follow the rule of one(*-ish*) process per container. But in some cases, running a whole bunch of containers for a relatively simple site may be overkill. Additional containers generally have some overhead in terms of CPU and, especially, memory usage.
+### Running other commands
+You can skip the execution of the `django-entrypoint.sh` script bootstrapping processes and run other commands by overriding the container's launch command.
 
-This image provides the option to run a Celery worker inside the container, alongside Gunicorn/Nginx. To run a Celery worker you must set the `CELERY_APP` environment variable.
+You can do this at image build-time by setting the `CMD` directive in your Dockerfile...
+```dockerfile
+CMD ["django-admin", "runserver"]
+```
+...or at runtime by passing an argument to the `docker run` command:
+```
+> $ docker run my-django-bootstrap-image django-admin runserver
+```
+
+
+If the entrypoint script sees a command for `gunicorn` then it will run all bootstrapping processes (database migration, starting Nginx, etc.). Otherwise, the script will execute the command directly. A special case is Celery, which is described next.
+
+## Celery
+It's common for Django applications to have [Celery](http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html) workers performing tasks alongside the actual website. Using this image, there are 2 different ways to run Celery:
+
+ 1. Run separate containers for Celery (recommended)
+ 2. Run Celery alongside the Django site inside the same container (simpler)
+
+In most cases it makes sense to run each Celery process in a container separate from the Django/Gunicorn one, so as to follow the rule of one(*-ish*) process per container. But in some cases, running a whole bunch of containers for a relatively simple site may be overkill. Additional containers generally have some overhead in terms of CPU and, especially, memory usage.
 
 Note that, as with Django, your project needs to specify Celery in its `install_requires` in order to use Celery. Celery is not installed in this image by default.
 
-### Configuration
+### Option 1: Celery containers
+To run a Celery container simply override the container command as described earlier. If the `django-entrypoint.sh` script sees a `celery` command, it will instead run the command using the [`celery-entrypoint.sh`](celery-entrypoint.sh) script. This script switches to the correct user to run Celery and sets some basic config options, depending on which Celery command is being run.
+
+You can override the command in your Dockerfile...
+```dockerfile
+CMD ["celery", "worker", \
+     "--app", "my_django_project", \
+     "--loglevel", "info"]
+```
+...or at runtime:
+```
+> $ docker run my-django-bootstrap-image celery worker --app my_django_project --loglevel info
+```
+
+You can also create dedicated Celery images by overriding the image entrypoint:
+```dockerfile
+ENTRYPOINT ["dinit", "celery-entrypoint.sh"]
+CMD ["worker", \
+     "--app", "my_django_project", \
+     "--loglevel", "INFO"]
+```
+
+### Option 2: Celery in the same container
+Celery can be enabled alongside Django/Gunicorn by adjusting a set of environment variables. Setting the `CELERY_APP` variable to the Celery app to run will enable a Celery worker process.
+
 The following environment variables can be used to configure Celery. A number of these can also be configured via the Django project's settings.
 
 #### `CELERY_APP`:
@@ -104,7 +134,7 @@ Note that by default Celery runs as many worker processes as there are processor
 * Celery option: `-c`/`--concurrency`
 
 #### `CELERY_BEAT`:
-Set this option to any non-empty value to have a [Celery beat](http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html) scheduler process run as well.
+Set this option to any non-empty value (e.g. "`1`") to have a [Celery beat](http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html) scheduler process run as well.
 * Required: no
 * Default: none
 * Celery option: n/a

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Let's go through these lines one-by-one:
  3. *Optional:* If you need to run any build-time tasks, such as collecting static assets, now's the time to do that.
  4. We set the container command (`CMD`) to a list of arguments that will be passed to `gunicorn`. We need to provide Gunicorn with the [`APP_MODULE`](http://docs.gunicorn.org/en/stable/run.html?highlight=app_module#gunicorn), so that it knows which WSGI app to run.*
 
-\*Note that previously the way to do this was to set the `APP_MODULE` environment variable. That still works, but is no longer the recommended way.
+\*Note that previously the way to do this was to set the `APP_MODULE` environment variable. That still works, but is no longer the recommended way and is deprecated.
 
 The `django-bootstrap:onbuild` base image does a few steps automatically using Docker's `ONBUILD` instruction. It will:
  1. `COPY . /app` - copies the source of your project into the image
@@ -144,14 +144,13 @@ Set this option to any non-empty value (e.g. "`1`") to have a [Celery beat](http
 ## Other configuration
 ### Gunicorn
 Gunicorn is run with some basic configuration:
-* Runs WSGI app defined in `APP_MODULE` environment variable
 * Starts workers under the `gunicorn` user and group
 * Listens on a Unix socket at `/var/run/gunicorn/gunicorn.sock`
 * Access logs can be logged to stderr by setting the `GUNICORN_ACCESS_LOGS` environment variable to a non-empty value.
 
 Extra settings can be provided by overriding the `CMD` instruction to pass extra parameters to the entrypoint script. For example:
 ```dockerfile
-CMD ["django-entrypoint.sh", "--threads", "5", "--timeout", "50"]
+CMD ["my_django_project.wsgi:application", "--threads", "5", "--timeout", "50"]
 ```
 
 See all the settings available for gunicorn [here](http://docs.gunicorn.org/en/latest/settings.html). A common setting is the number of Gunicorn workers which can be set with the `WEB_CONCURRENCY` environment variable.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The following environment variables can be used to configure Celery. A number of
 
 #### `CELERY_LOGLEVEL`:
 * Required: no
-* Default: `INFO`
+* Default: none
 * Celery option: `-l`/`--loglevel`
 
 #### `CELERY_CONCURRENCY`:

--- a/celery-entrypoint.sh
+++ b/celery-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Add 'celery' to the front of the command if it's not there already
-[ "$1" != 'celery' ] || set -- celery "$@"
+[ "$1" = 'celery' ] || set -- celery "$@"
 
 # Set some common options if the env vars are set
 set -- "$@" \

--- a/celery-entrypoint.sh
+++ b/celery-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+set -e
+
+# Add 'celery' to the front of the command if it's not there already
+[ "$1" != 'celery' ] || set -- celery "$@"
+
+# Set some common options if the env vars are set
+set -- "$@" \
+    ${CELERY_APP:+--app "$CELERY_APP"} \
+    ${CELERY_BROKER:+--broker "$CELERY_BROKER"} \
+    ${CELERY_LOGLEVEL:+--loglevel "$CELERY_LOGLEVEL"}
+
+# Set the concurrency if this is a worker
+if [ "$2" = 'worker' ]; then
+  set -- "$@" --concurrency "${CELERY_CONCURRENCY:-1}"
+fi
+
+# Set the schedule file if this is beat
+if [ "$2" = 'beat' ]; then
+  set -- "$@" --schedule /var/run/celery/celerybeat-schedule
+fi
+
+exec su-exec celery "$@"

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -31,23 +31,11 @@ nginx -g 'daemon off;' &
 # Celery
 if [ -n "$CELERY_APP" ]; then
   # Worker
-  su-exec celery \
-    celery worker \
-      --pidfile /var/run/celery/worker.pid \
-      --app "$CELERY_APP" \
-      ${CELERY_BROKER:+--broker "$CELERY_BROKER"} \
-      --loglevel "${CELERY_LOGLEVEL:-INFO}" \
-      --concurrency "${CELERY_CONCURRENCY:-1}" &
+  celery-entrypoint.sh worker --pidfile /var/run/celery/worker.pid &
 
   # Beat
   if [ -n "$CELERY_BEAT" ]; then
-    su-exec celery \
-      celery beat \
-        --pidfile /var/run/celery/beat.pid \
-        --schedule /var/run/celery/celerybeat-schedule \
-        --app "$CELERY_APP" \
-        ${CELERY_BROKER:+--broker "$CELERY_BROKER"} \
-        --loglevel "${CELERY_LOGLEVEL:-INFO}" &
+    celery-entrypoint.sh beat --pidfile /var/run/celery/beat.pid &
   fi
 fi
 

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -47,13 +47,19 @@ if not User.objects.filter(username='admin').exists():
     fi
   fi
 
+  if [ -n "$APP_MODULE" ]; then
+    echo 'DEPRECATED: Providing APP_MODULE via an environment variable is deprecated.
+            Please provide it using the container command rather.' 1>&2
+    set -- "$@" "$APP_MODULE"
+  fi
+
   # Set some sensible Gunicorn options, needed for things to work with Nginx
 
   # umask working files (worker tmp files & unix socket) as 0o117 (i.e. chmod as
   # 0o660) so that they are only read/writable by gunicorn and nginx users.
   # FIXME: Have to specify umask as decimal, not octal (0o117 = 79):
   # https://github.com/benoitc/gunicorn/issues/1325
-  set -- "$@" $APP_MODULE \
+  set -- "$@" \
     --pid /var/run/gunicorn/gunicorn.pid \
     --user gunicorn --group gunicorn --umask 79 \
     --bind unix:/var/run/gunicorn/gunicorn.sock \

--- a/example/py2.dockerfile
+++ b/example/py2.dockerfile
@@ -1,4 +1,4 @@
 FROM praekeltfoundation/django-bootstrap:py2-onbuild
-ENV DJANGO_SETTINGS_MODULE "mysite.settings"
+ENV DJANGO_SETTINGS_MODULE mysite.settings
 RUN django-admin collectstatic --noinput
-ENV APP_MODULE "mysite.wsgi:application"
+CMD ["mysite.wsgi:application"]

--- a/example/py3.dockerfile
+++ b/example/py3.dockerfile
@@ -1,4 +1,4 @@
 FROM praekeltfoundation/django-bootstrap:py3-onbuild
-ENV DJANGO_SETTINGS_MODULE "mysite.settings"
+ENV DJANGO_SETTINGS_MODULE mysite.settings
 RUN django-admin collectstatic --noinput
-ENV APP_MODULE "mysite.wsgi:application"
+CMD ["mysite.wsgi:application"]

--- a/py2.dockerfile
+++ b/py2.dockerfile
@@ -31,5 +31,6 @@ RUN pip install -r /requirements.txt
 EXPOSE 8000
 WORKDIR /app
 
-COPY django-entrypoint.sh /scripts/
+COPY django-entrypoint.sh celery-entrypoint.sh \
+    /scripts/
 CMD ["django-entrypoint.sh"]

--- a/py2.dockerfile
+++ b/py2.dockerfile
@@ -33,4 +33,5 @@ WORKDIR /app
 
 COPY django-entrypoint.sh celery-entrypoint.sh \
     /scripts/
-CMD ["django-entrypoint.sh"]
+ENTRYPOINT ["dinit", "django-entrypoint.sh"]
+CMD []

--- a/py3.dockerfile
+++ b/py3.dockerfile
@@ -31,5 +31,6 @@ RUN pip install -r /requirements.txt
 EXPOSE 8000
 WORKDIR /app
 
-COPY django-entrypoint.sh /scripts/
+COPY django-entrypoint.sh celery-entrypoint.sh \
+    /scripts/
 CMD ["django-entrypoint.sh"]

--- a/py3.dockerfile
+++ b/py3.dockerfile
@@ -33,4 +33,5 @@ WORKDIR /app
 
 COPY django-entrypoint.sh celery-entrypoint.sh \
     /scripts/
-CMD ["django-entrypoint.sh"]
+ENTRYPOINT ["dinit", "django-entrypoint.sh"]
+CMD []


### PR DESCRIPTION
* Add a separate entrypoint script for Celery so Celery commands can be run under the correct user and with limited processes easily.
* Rework `django-entrypoint.sh` to actually be an entrypoint script.
* Deprecate `APP_MODULE` env var. Set the app module for Gunicorn via `CMD` now.
* README work for all this.