### PR TITLE
Gunicorn hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,5 @@ Nginx is set up with mostly default config:
 Generally you shouldn't need to adjust Nginx's settings. If you do, the configuration files of interest are at:
 * `/etc/nginx/nginx.conf`: Main configuration
 * `/etc/nginx/conf.d/django.conf`: Proxy configuration
+
+We make a few adjustments to Nginx's default configuration to better work with Gunicorn. See the [config file](nginx/conf.d/django.conf) for all the details. One important point is that we consider the `X-Forwarded-Proto` header, when set to the value of `https`, as an indicator that the client connection was made over HTTPS and is secure. Gunicorn considers a few more headers for this purpose, `X-Forwarded-Protocol` and `X-Forwarded-Ssl`, but our Nginx config is set to remove those headers to prevent misuse.

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -65,7 +65,7 @@ if not User.objects.filter(username='admin').exists():
   set -- su-exec gunicorn "$@" \
     --pid /var/run/gunicorn/gunicorn.pid \
     --bind unix:/var/run/gunicorn/gunicorn.sock \
-    --umask 0o117 \
+    --umask 0117 \
     ${GUNICORN_ACCESS_LOGS:+--access-logfile -}
 fi
 

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -62,12 +62,10 @@ if not User.objects.filter(username='admin').exists():
 
   # umask working files (worker tmp files & unix socket) as 0o117 (i.e. chmod as
   # 0o660) so that they are only read/writable by gunicorn and nginx users.
-  # FIXME: Have to specify umask as decimal, not octal (0o117 = 79):
-  # https://github.com/benoitc/gunicorn/issues/1325
-  set -- "$@" \
+  set -- su-exec gunicorn "$@" \
     --pid /var/run/gunicorn/gunicorn.pid \
-    --user gunicorn --group gunicorn --umask 79 \
     --bind unix:/var/run/gunicorn/gunicorn.sock \
+    --umask 0o117 \
     ${GUNICORN_ACCESS_LOGS:+--access-logfile -}
 fi
 

--- a/nginx/conf.d/django.conf
+++ b/nginx/conf.d/django.conf
@@ -39,5 +39,16 @@ server {
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # We only use the 'X-Forwarded-Proto' header from our load-balancer to
+        # indicate the original connection used HTTPS, but Gunicorn by default
+        # accepts more headers than that:
+        # http://docs.gunicorn.org/en/19.7.1/settings.html#secure-scheme-headers
+        # Overriding that config in Gunicorn is a bit complicated, and could
+        # easily be overriden by accident by the user, so just delete those
+        # other headers here so that a client can't set them
+        # incorrectly/maliciously.
+        proxy_set_header X-Forwarded-Protocol "";
+        proxy_set_header X-Forwarded-Ssl "";
     }
 }


### PR DESCRIPTION
* Run all Gunicorn processes as non-root (including the master)
* Make Nginx clear headers that Gunicorn considers to indicate an HTTPS connection (except `X-Forwarded-Proto`)