### PR TITLE
Improve HTTP Cache-Control setup

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -6,6 +6,8 @@ django-admin startproject mysite
 
 A `setup.py` was added to install dependencies. An example [Django settings file](mysite/docker_settings.py) was also added to make configuration in a Docker container easier. An example Celery setup (see [`celery.py`](mysite/celery.py)) was added as well.
 
+[django-compressor](https://django-compressor.readthedocs.io) is set up to compress some JavaScript and CSS in a dummy template.
+
 ## Usage
 A [Docker Compose file](docker-compose.yml) is provided that sets up some infrastructure (RabbitMQ and PostgreSQL instances) for the container to use.
 

--- a/example/mysite/docker_settings.py
+++ b/example/mysite/docker_settings.py
@@ -32,11 +32,11 @@ DATABASES = {
 # Set up static file storage as described in the README
 STATIC_ROOT = '/app/static'
 STATIC_URL = '/static/'
-# Using CachedStaticFilesStorage results in a larger Docker image but means
+# Using ManifestStaticFilesStorage results in a larger Docker image but means
 # that Nginx can set long 'expires' headers for the files.
 # https://github.com/praekeltfoundation/docker-django-bootstrap/pull/11
 STATICFILES_STORAGE = (
-    'django.contrib.staticfiles.storage.CachedStaticFilesStorage')
+    'django.contrib.staticfiles.storage.ManifestStaticFilesStorage')
 
 MEDIA_ROOT = '/app/media'
 MEDIA_URL = '/media/'

--- a/example/mysite/settings.py
+++ b/example/mysite/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'compressor',
 ]
 
 MIDDLEWARE = [
@@ -54,7 +55,7 @@ ROOT_URLCONF = 'mysite.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': ['mysite/templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -118,3 +119,11 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Set up django-compressor
+STATICFILES_FINDERS = [
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+]
+COMPRESS_OFFLINE = True

--- a/example/mysite/templates/template.html
+++ b/example/mysite/templates/template.html
@@ -1,0 +1,10 @@
+{# Dummy template with gibberish CSS and JS to test django-compressor #}
+{% load compress %}
+
+{% compress css %}
+<style type="text/css">p { border:5px solid green;}</style>
+{% endcompress %}
+
+{% compress js %}
+<script type="text/javascript" charset="utf-8">obj.value = "value";</script>
+{% endcompress %}

--- a/example/py2.dockerfile
+++ b/example/py2.dockerfile
@@ -1,5 +1,6 @@
 FROM praekeltfoundation/django-bootstrap:py2-onbuild
 ENV DJANGO_SETTINGS_MODULE mysite.docker_settings
 ENV CELERY_APP mysite
-RUN django-admin collectstatic --noinput
+RUN django-admin collectstatic --noinput \
+    && django-admin compress
 CMD ["mysite.wsgi:application"]

--- a/example/py3.dockerfile
+++ b/example/py3.dockerfile
@@ -1,5 +1,6 @@
 FROM praekeltfoundation/django-bootstrap:py3-onbuild
 ENV DJANGO_SETTINGS_MODULE mysite.docker_settings
 ENV CELERY_APP mysite
-RUN django-admin collectstatic --noinput
+RUN django-admin collectstatic --noinput \
+    && django-admin compress
 CMD ["mysite.wsgi:application"]

--- a/example/setup.py
+++ b/example/setup.py
@@ -9,6 +9,7 @@ setup(
     install_requires=[
         'celery >=4.0, <4.1',
         'Django >=1.11, <1.12',
+        'django_compressor >=2.1',
         'django-environ',
         'psycopg2 >=2.7',
     ],

--- a/example/test.sh
+++ b/example/test.sh
@@ -80,10 +80,12 @@ curl -fsL http://localhost:$WEB_PORT/admin | fgrep '<title>Log in | Django site 
 curl -fsL http://localhost:$WEB_PORT/static/admin/css/base.css | fgrep 'DJANGO Admin styles'
 
 # Check that the caching header is set for a hashed file
-curl -fsI http://localhost:$WEB_PORT/static/admin/img/search.7cf54ff789c6.svg | fgrep 'Cache-Control: max-age=315360000'
+curl -fsI http://localhost:$WEB_PORT/static/admin/img/search.7cf54ff789c6.svg \
+  | fgrep 'Cache-Control: max-age=315360000, public, immutable'
 
-# Check that the caching header is *not* set for a file that isn't hashed
-curl -fsI http://localhost:$WEB_PORT/static/admin/img/search.svg | fgrep -v 'Cache-Control'
+# Check that the caching header is set to the default for a non-hashed file
+curl -fsI http://localhost:$WEB_PORT/static/admin/img/search.svg \
+  | fgrep 'Cache-Control: max-age=60, public'
 
 # Check tables were created in the database
 [[ $(compose_cmd exec --user postgres db \

--- a/example/test.sh
+++ b/example/test.sh
@@ -83,6 +83,16 @@ curl -fsL http://localhost:$WEB_PORT/static/admin/css/base.css | fgrep 'DJANGO A
 curl -fsI http://localhost:$WEB_PORT/static/admin/img/search.7cf54ff789c6.svg \
   | fgrep 'Cache-Control: max-age=315360000, public, immutable'
 
+# Check that a compressed JavaScript file has the correct Cache-Control header
+COMPRESSED_JS_FILE="$(compose_cmd exec web find static/CACHE/js -name '*.js' | head -1 | tr -d '\r')"
+curl -fsI http://localhost:$WEB_PORT/$COMPRESSED_JS_FILE \
+  | fgrep 'Cache-Control: max-age=315360000, public, immutable'
+
+# Check the same for a compressed CSS file
+COMPRESSED_CSS_FILE="$(compose_cmd exec web find static/CACHE/css -name '*.css' | head -1 | tr -d '\r')"
+curl -fsI http://localhost:$WEB_PORT/$COMPRESSED_CSS_FILE \
+  | fgrep 'Cache-Control: max-age=315360000, public, immutable'
+
 # Check that the caching header is set to the default for a non-hashed file
 curl -fsI http://localhost:$WEB_PORT/static/admin/img/search.svg \
   | fgrep 'Cache-Control: max-age=60, public'

--- a/nginx/conf.d/django.conf
+++ b/nginx/conf.d/django.conf
@@ -4,6 +4,33 @@ upstream gunicorn {
     server unix:/var/run/gunicorn/gunicorn.sock max_fails=0;
 }
 
+# Detect filenames for static files that look like they contain MD5 hashes as
+# these can be cached indefinitely.
+
+# Nginx's 'expires max' directive sets the Cache-Control header to have a max-
+# age of 10 years. It also sets the Expires header to a certain date in 2037:
+# http://nginx.org/en/docs/http/ngx_http_headers_module.html#expires
+
+# We also want to add the 'public' and 'immutable' values to the Cache-Control
+# header to prevent clients from revalidating files that we know are immutable:
+# https://bitsup.blogspot.co.za/2016/05/cache-control-immutable.html
+
+# Using 'expires max' makes adding other Cache-Control values tricky and the
+# The Expires header should be ignored when a max-age is set for Cache-Control:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expires
+
+# So, avoid 'expires max' & just add the header manually with a 10-year max-age.
+map $uri $static_cache_control {
+    # ManifestStaticFilesStorage files have a hash in the middle of the filename
+    "~^/static/.*/[^/\.]+\.[a-f0-9]{12}\.\w+$"         "max-age=315360000, public, immutable";
+
+    # django-compressor cached files are js/css with a hash filename
+    "~^/static/CACHE/(js|css)/[a-f0-9]{12}\.(js|css)$" "max-age=315360000, public, immutable";
+
+    # For the default, copy what WhiteNoise does and set a short max-age
+    default                                            "max-age=60, public";
+}
+
 server {
     listen 8000;
 
@@ -13,19 +40,7 @@ server {
         # Fallback for projects still using STATIC_ROOT = BASE_DIR/staticfiles
         # as recommended by WhiteNoise
         try_files /static/$1 /staticfiles/$1 =404;
-
-        # Detect filenames for static files that look like they contain MD5
-        # hashes as these can be cached indefinitely.
-
-        # ManifestStaticFilesStorage have a hash in the middle of the filename
-        location ~ "^/static/.*/[^/\.]+\.[a-f0-9]{12}\.\w+$" {
-            expires max;
-        }
-
-        # django-compressor cached files are js/css with a hash filename
-        location ~ "^/static/CACHE/(js|css)/[a-f0-9]{12}\.(js|css)$" {
-            expires max;
-        }
+        add_header Cache-Control $static_cache_control;
     }
 
     location ~ ^/media/?(.*)$ {

--- a/nginx/conf.d/django.conf
+++ b/nginx/conf.d/django.conf
@@ -17,14 +17,14 @@ server {
         # Detect filenames for static files that look like they contain MD5
         # hashes as these can be cached indefinitely.
 
-        # CachedStaticFilesStorage have a hash in the middle of the filename
+        # ManifestStaticFilesStorage have a hash in the middle of the filename
         location ~ "^/static/.*/[^/\.]+\.[a-f0-9]{12}\.\w+$" {
-          expires max;
+            expires max;
         }
 
         # django-compressor cached files are js/css with a hash filename
         location ~ "^/static/CACHE/(js|css)/[a-f0-9]{12}\.(js|css)$" {
-          expires max;
+            expires max;
         }
     }
 


### PR DESCRIPTION
* Recommend `ManifestStaticFilesStorage` over `CachedStaticFilesStorage`
* Use a map instead of nested locations
* Set the `immutable` and `public` settings
* Set a short `max-age` for unhashed files
* Add tests for django-compressor static files