### PR TITLE
More useful Nginx access logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ See all the settings available for gunicorn [here](http://docs.gunicorn.org/en/l
 
 ### Nginx
 Nginx is set up with mostly default config:
-* Access logs are sent to stdout, error logs to stderr and log messages are prefixed with `nginx: ` to differentiate them from Gunicorn log messages
+* Access logs are sent to stdout, error logs to stderr and log messages are prefixed formatted to be JSON-compatible for easy parsing.
 * Listens on port 8000 (and this port is exposed in the Dockerfile)
 * Serves files from `/static/` and `/media/`
 * All other requests are proxied to the Gunicorn socket

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ See all the settings available for gunicorn [here](http://docs.gunicorn.org/en/l
 
 ### Nginx
 Nginx is set up with mostly default config:
-* Access logs are sent to stdout, error logs to stderr and log messages are prefixed formatted to be JSON-compatible for easy parsing.
+* Access logs are sent to stdout, error logs to stderr and log messages are formatted to be JSON-compatible for easy parsing.
 * Listens on port 8000 (and this port is exposed in the Dockerfile)
 * Serves files from `/static/` and `/media/`
 * All other requests are proxied to the Gunicorn socket

--- a/example/test.sh
+++ b/example/test.sh
@@ -74,7 +74,7 @@ compose_cmd ps web | grep 'Up'
 WEB_PORT="$(compose_cmd port web 8000 | cut -d':' -f2)"
 
 # Simple check to see if the site is up
-curl -fsL http://localhost:$WEB_PORT/admin | fgrep '<title>Log in | Django site admin</title>'
+curl -fsL http://localhost:$WEB_PORT/admin/ | fgrep '<title>Log in | Django site admin</title>'
 
 # Check our Nginx access logs work and are valid JSON
 compose_cmd logs web | grep -m 1 -o -E '\{ "time": .+' | jq .

--- a/example/test.sh
+++ b/example/test.sh
@@ -76,6 +76,9 @@ WEB_PORT="$(compose_cmd port web 8000 | cut -d':' -f2)"
 # Simple check to see if the site is up
 curl -fsL http://localhost:$WEB_PORT/admin | fgrep '<title>Log in | Django site admin</title>'
 
+# Check our Nginx access logs work and are valid JSON
+compose_cmd logs web | grep -m 1 -o -E '\{ "time": .+' | jq .
+
 # Check that we can get a static file served by Nginx
 curl -fsL http://localhost:$WEB_PORT/static/admin/css/base.css | fgrep 'DJANGO Admin styles'
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -30,6 +30,7 @@ http {
             '"request": "$request", '
             '"status": $status, '
             '"body_bytes_sent": $body_bytes_sent, '
+            '"request_time": $request_time, '
             '"http_referer": "$http_referer", '
             '"http_user_agent": "$http_user_agent", '
             '"http_x_forwarded_proto": "$http_x_forwarded_proto", '

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -32,6 +32,7 @@ http {
             '"body_bytes_sent": $body_bytes_sent, '
             '"http_referer": "$http_referer", '
             '"http_user_agent": "$http_user_agent", '
+            '"http_x_forwarded_proto": "$http_x_forwarded_proto", '
             '"http_x_forwarded_for": "$http_x_forwarded_for" '
         '}';
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -31,6 +31,7 @@ http {
             '"status": $status, '
             '"body_bytes_sent": $body_bytes_sent, '
             '"request_time": $request_time, '
+            '"http_host": "$http_host", '
             '"http_referer": "$http_referer", '
             '"http_user_agent": "$http_user_agent", '
             '"http_via": "$http_via", '

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -33,6 +33,7 @@ http {
             '"request_time": $request_time, '
             '"http_referer": "$http_referer", '
             '"http_user_agent": "$http_user_agent", '
+            '"http_via": "$http_via", '
             '"http_x_forwarded_proto": "$http_x_forwarded_proto", '
             '"http_x_forwarded_for": "$http_x_forwarded_for" '
         '}';

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,9 +19,21 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  'nginx: $remote_addr - $remote_user [$time_local] '
-                      '"$request" $status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+    # Use a JSON-compatible log format. The default Nginx log format has
+    # unlabeled fields that makes it tricky to parse. Since Nginx 1.11.8,
+    # `escape=json` is available to escape variables.
+    log_format main escape=json
+        '{ '
+            '"time": "$time_local", '
+            '"remote_addr": "$remote_addr", '
+            '"remote_user": "$remote_user", '
+            '"request": "$request", '
+            '"status": $status, '
+            '"body_bytes_sent": $body_bytes_sent, '
+            '"http_referer": "$http_referer", '
+            '"http_user_agent": "$http_user_agent", '
+            '"http_x_forwarded_for": "$http_x_forwarded_for" '
+        '}';
 
     access_log  /dev/stdout  main;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -24,7 +24,7 @@ http {
     # `escape=json` is available to escape variables.
     log_format main escape=json
         '{ '
-            '"time": "$time_local", '
+            '"time": "$time_iso8601", '
             '"remote_addr": "$remote_addr", '
             '"remote_user": "$remote_user", '
             '"request": "$request", '


### PR DESCRIPTION
* Format logs as JSON
* Use ISO8601 time format
* Log `X-Forwarded-Proto` header
* Log `$request_time`
* Log `Via` header
* Log `Host` header