### PR TITLE
Remove text/html from gzip_types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -78,8 +78,9 @@ http {
         image/x-icon # 'x-icon' seems to be used more commonly than 'vnd.microsoft.icon'
 
         # Text types
+        # text/html is compressed by default:
+        # https://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_types
         text/css
-        text/html
         text/plain;
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
When I run an app built from this base, nginx logs:

```
nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/nginx.conf:83
```

This is because text/html is always enabled by default (at least for this version of nginx, 1.12.1).