### PR TITLE
Move comment about nginx user out of command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,11 @@ RUN apt-get-install.sh libpq5
 
 # Install a modern Nginx and configure
 ENV NGINX_VERSION 1.12.1-1~jessie
+# Add nginx user to django group so that Nginx can read/write to gunicorn socket
 RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62 \
     && echo 'deb http://nginx.org/packages/debian/ jessie nginx' > /etc/apt/sources.list.d/nginx.list \
     && apt-get-install.sh "nginx=$NGINX_VERSION" \
     && rm /etc/nginx/conf.d/default.conf \
-# Add nginx user to django group so that Nginx can read/write to gunicorn socket
     && adduser nginx django
 COPY nginx/ /etc/nginx/
 


### PR DESCRIPTION
Docker 17.07 says:

> [WARNING]: Empty continuation line found
>
> [WARNING]: Empty continuation lines will become errors in a future release.