### PR TITLE
Improve Nginx GPG key verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex; \
     apt-key add nginx_signing.key; \
     codename="$(. /etc/os-release; echo $VERSION | grep -oE [a-z]+)"; \
     echo "deb http://nginx.org/packages/debian/ $codename nginx" > /etc/apt/sources.list.d/nginx.list; \
-    rm nginx_signing.key
+    rm nginx_signing.key; \
     apt-get-purge.sh $fetchDeps; \
     \
     apt-get-install.sh "nginx=$NGINX_VERSION-1\~$codename"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,13 @@ RUN set -ex; \
         $(command -v gpg > /dev/null || echo 'dirmngr gnupg') \
     "; \
     apt-get-install.sh $fetchDeps; \
-    wget -O- https://nginx.org/keys/nginx_signing.key | apt-key add -; \
-    apt-key adv --fingerprint "$NGINX_GPG_KEY"; \
+    wget https://nginx.org/keys/nginx_signing.key; \
+    [ "$(gpg -q --with-fingerprint --with-colons nginx_signing.key | awk -F: '/^fpr:/ { print $10 }')" \
+        = $NGINX_GPG_KEY ]; \
+    apt-key add nginx_signing.key; \
     codename="$(. /etc/os-release; echo $VERSION | grep -oE [a-z]+)"; \
     echo "deb http://nginx.org/packages/debian/ $codename nginx" > /etc/apt/sources.list.d/nginx.list; \
+    rm nginx_signing.key
     apt-get-purge.sh $fetchDeps; \
     \
     apt-get-install.sh "nginx=$NGINX_VERSION-1\~$codename"; \

--- a/example/setup.py
+++ b/example/setup.py
@@ -7,7 +7,7 @@ setup(
     author_email='sre@praekelt.org',
     packages=['mysite'],
     install_requires=[
-        'celery >=4.0, <4.1',
+        'celery >=4.1, <4.2',
         # This version seems to be broken with Python 3:
         # https://github.com/celery/py-amqp/issues/155
         'amqp != 2.2.0',


### PR DESCRIPTION
* This copies roughly what Puppet's `apt::key` does. The gpg + awk command comes from the source for that.
* `apt-key` output is not meant to be parsed, apparently.
* The check before was _technically_ imprecise...it checked only that one of the imported keys had the right fingerprint, not that there was _one_ imported key and that key had the expected fingerprint.
* `gpg` is a finicky tool that really wants you to import keys into a keychain in order to use it and I don't like that.