### PR TITLE
Create runtime directories at runtime and recommend mounting /run as a tmpfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,7 @@ FROM praekeltfoundation/python-base:${PYTHON_VERSION}
 # Create the user and working directories first as they shouldn't change often.
 # Specify the UID/GIDs so that they do not change somehow and mess with the
 # ownership of external volumes.
-RUN set -ex; \
-    addgroup --system --gid 107 django; \
-    adduser --system --uid 104 --ingroup django django; \
-    \
-    mkdir /run/gunicorn /run/celery; \
-    chown django:django /run/gunicorn /run/celery
+RUN addgroup --system --gid 107 django && adduser --system --uid 104 --ingroup django django
 
 # Install libpq for psycopg2 for PostgreSQL support
  RUN apt-get-install.sh libpq5

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ For more background on running Django in Docker containers, see [this talk](http
 3. [Choosing an image tag](#choosing-an-image-tag)
 4. [Monitoring and metrics](#monitoring-and-metrics)
    - [Health checks](#health-checks)
-5. [Frequently asked questions](#frequently-asked-questions)
+5. [Production-readiness](#production-readiness)
+6. [Frequently asked questions](#frequently-asked-questions)
    - [How is this deployed?](#how-is-this-deployed)
    - [Why is Nginx needed?](#why-is-nginx-needed)
    - [What about WhiteNoise?](#what-about-whitenoise)
    - [What about Gunicorn's async workers?](#what-about-gunicorns-async-workers)
    - [What about Django Channels?](#what-about-django-channels)
-6. [Other configuration](#other-configuration)
+7. [Other configuration](#other-configuration)
    - [Gunicorn](#gunicorn)
    - [Nginx](#nginx)
 
@@ -269,6 +270,13 @@ There are a few popular libraries available for implementing health checks in Dj
 * [`django-healthchecks`](https://github.com/mvantellingen/django-healthchecks)
 
 The [example Django projects](tests) we use to test `django-bootstrap` use a very basic configuration of [`django-health-check`](https://github.com/KristianOellegaard/django-health-check). Health checks can also be implemented from scratch in Django quite easily.
+
+## Production-readiness
+django-bootstrap has been used in production at [Praekelt.org](https://www.praekelt.org) for several years now for thousands of containers serving millions of users around the world. django-bootstrap was designed to encapsulate many of our best practices for deploying production-ready Django.
+
+That said, care should be taken in configuring containers at runtime with the appropriate settings. Here are a few points to check on:
+* If using Gunicorn's default synchronous workers, you should set the `WEB_CONCURRENCY` environment variable to some number greater than 1 (the default). Gunicorn has some [recommendations](http://docs.gunicorn.org/en/latest/design.html#how-many-workers).
+* Consider mounting the `/run` directory as a `tmpfs` volume. This can help improve performance consistency due to [the way Gunicorn handles signaling](http://docs.gunicorn.org/en/latest/faq.html#blocking-os-fchmod) between workers.
 
 ## Frequently asked questions
 ### How is this deployed?

--- a/README.md
+++ b/README.md
@@ -324,8 +324,9 @@ This is a direction we want to take the project, but currently our infrastructur
 ## Other configuration
 ### Gunicorn
 Gunicorn is run with some basic configuration using the config file at [`/gunicorn_conf.py`](gunicorn_conf.py):
-* Starts workers under the `django` user and group
 * Listens on a Unix socket at `/run/gunicorn/gunicorn.sock`
+* Places a PID file at `/run/gunicorn/gunicorn.pid`
+* [Worker temporary files](http://docs.gunicorn.org/en/latest/settings.html#worker-tmp-dir) are placed in `/run/gunicorn`
 * Access logs can be logged to stderr by setting the `GUNICORN_ACCESS_LOGS` environment variable to a non-empty value.
 
 ### Nginx

--- a/celery-entrypoint.sh
+++ b/celery-entrypoint.sh
@@ -44,6 +44,10 @@ if [ "$1" = 'celery' ]; then
   # Run under the celery user
   set -- su-exec django "$@"
 
+  # Create the Celery runtime directory at runtime in case /run is a tmpfs
+  if mkdir /run/celery 2> /dev/null; then
+    chown django:django /run/celery
+  fi
   # Celery by default writes files like pidfiles and the beat schedule file to
   # the current working directory. Change to the Celery working directory so
   # that these files end up there.

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -63,6 +63,11 @@ if not User.objects.filter(username='admin').exists():
     set -- "$@" "$APP_MODULE"
   fi
 
+  # Create the Gunicorn runtime directory at runtime in case /run is a tmpfs
+  if mkdir /run/gunicorn 2> /dev/null; then
+    chown django:django /run/gunicorn
+  fi
+
   set -- su-exec django "$@" --config /gunicorn_conf.py
 fi
 

--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -10,6 +10,11 @@ bind = "unix:/run/gunicorn/gunicorn.sock"
 # umask working files (worker tmp files & unix socket) as 0o117 (i.e. chmod as
 # 0o660) so that they are only read/writable by django and nginx users.
 umask = 0o117
+# Set the worker temporary file directory to /run/gunicorn (rather than default
+# of /tmp) so that all of Gunicorn's files are in one place and a tmpfs can be
+# mounted at /run for better performance.
+# http://docs.gunicorn.org/en/latest/faq.html#blocking-os-fchmod
+worker_tmp_dir = "/run/gunicorn"
 
 if os.environ.get("GUNICORN_ACCESS_LOGS"):
     accesslog = "-"

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -34,8 +34,8 @@ class _BaseContainerDefinition(ContainerDefinition):
     def list_processes(self):
         return list_container_processes(self.inner())
 
-    def exec_run(self, args):
-        return output_lines(self.inner().exec_run(args))
+    def exec_run(self, args, **kwargs):
+        return output_lines(self.inner().exec_run(args, **kwargs))
 
     def exec_find(self, params):
         return self.exec_run(['find'] + params)

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -63,10 +63,14 @@ class GunicornContainer(_BaseContainerDefinition):
         kwargs = {
             'command': command,
             'environment': env,
-            # Add a tmpfs mount at /app/media so that we can test ownership of
-            # the directory is set. Normally a proper volume would be mounted
-            # but the effect is the same.
-            'tmpfs': {'/app/media': 'uid=0'},
+            'tmpfs': {
+                # Everything in /run should be ephemeral and created at runtime
+                '/run': '',
+                # Add a tmpfs mount at /app/media so that we can test ownership
+                # of the directory is set. Normally a proper volume would be
+                # mounted but the effect is the same.
+                '/app/media': 'uid=0'
+            },
             'ports': {'8000/tcp': ('127.0.0.1',)}
         }
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -227,8 +227,8 @@ class TestWeb(object):
             [t for t in ceci_nest_pas_une_pipe if not t.startswith(sock_path)])
 
         # Finally, assert the worker temp file is in the place we expect
-        [file] = neither_pipes_nor_socks
-        assert_that(file, StartsWith('/run/gunicorn/wgunicorn-'))
+        assert_that(neither_pipes_nor_socks, MatchesListwise(
+            [StartsWith('/run/gunicorn/wgunicorn-')])
 
     @pytest.mark.clean_db_container
     def test_database_tables_created(self, db_container, web_container):

--- a/tests/test.py
+++ b/tests/test.py
@@ -17,7 +17,7 @@ from testtools.assertions import assert_that
 from testtools.matchers import (
     AfterPreprocessing as After, Contains, Equals, GreaterThan, HasLength,
     LessThan, MatchesAll, MatchesAny, MatchesDict, MatchesListwise,
-    MatchesRegex, MatchesSetwise, Not)
+    MatchesRegex, MatchesSetwise, Not, StartsWith)
 
 from definitions import (  # noqa: I100,I101
     # dependencies
@@ -172,6 +172,8 @@ class TestWeb(object):
             '644 django:django',
         ]))
 
+        self._assert_gunicorn_worker_tmp_file(web_only_container)
+
     def test_expected_files_single_container(self, single_container):
         """
         When the container is running, there should be PID files for Nginx,
@@ -197,6 +199,36 @@ class TestWeb(object):
             '644 django:django',
             '644 django:django',
         ]))
+
+        self._assert_gunicorn_worker_tmp_file(single_container)
+
+    def _assert_gunicorn_worker_tmp_file(self, container):
+        # Find the worker temporary file...this is quite involved because it's
+        # a temp file without a predictable name and Gunicorn unlinks it so we
+        # can't just stat it
+        ps_rows = container.list_processes()
+        gunicorns = [r for r in ps_rows if '/usr/local/bin/gunicorn' in r.args]
+        worker = gunicorns[-1]  # Already sorted by PID, pick the highest PID
+        proc_fd_path = '/proc/{}/fd'.format(worker.pid)
+
+        # Due to container restrictions, the root user doesn't have access to
+        # /proc/pid/fd/*--we must run as the django user.
+        fd_targets = container.exec_run([
+            'bash', '-c',
+            'for fd in {}/*; do readlink -f "$fd"; done'.format(proc_fd_path)
+        ], user='django')
+
+        # Filter out non-file things
+        pipe_path = '{}/pipe'.format(proc_fd_path)
+        ceci_nest_pas_une_pipe = (
+            [t for t in fd_targets if not t.startswith(pipe_path)])
+        sock_path = '{}/socket'.format(proc_fd_path)
+        neither_pipes_nor_socks = (
+            [t for t in ceci_nest_pas_une_pipe if not t.startswith(sock_path)])
+
+        # Finally, assert the worker temp file is in the place we expect
+        [file] = neither_pipes_nor_socks
+        assert_that(file, StartsWith('/run/gunicorn/wgunicorn-'))
 
     @pytest.mark.clean_db_container
     def test_database_tables_created(self, db_container, web_container):

--- a/tests/test.py
+++ b/tests/test.py
@@ -228,7 +228,7 @@ class TestWeb(object):
 
         # Finally, assert the worker temp file is in the place we expect
         assert_that(neither_pipes_nor_socks, MatchesListwise(
-            [StartsWith('/run/gunicorn/wgunicorn-')])
+            [StartsWith('/run/gunicorn/wgunicorn-')]))
 
     @pytest.mark.clean_db_container
     def test_database_tables_created(self, db_container, web_container):


### PR DESCRIPTION
This is something I've been meaning to do for a while but it coincides with the Prometheus work. The Prometheus client in multiprocess mode writes metrics to temporary files (looks like their location will be `/run/gunicorn/prometheus`) that are shared between processes. Those files are already a fairly optimised [mmap-ed dict](https://github.com/prometheus/client_python/blob/master/prometheus_client/mmap_dict.py), but we want to avoid blocking workers wherever possible (I think? Am I making sense?)