### PR TITLE
Upgrade to GitHub-native Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "07:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: idna
+    versions:
+    - "< 2.9, >= 2.8.a"
+  - dependency-name: gunicorn
+    versions:
+    - 20.0.4


### PR DESCRIPTION
Rebase of [Upgrade to GitHub-native Dependabot](https://github.com/praekeltfoundation/docker-django-bootstrap/pull/123)